### PR TITLE
Added performance improvements for multiple chunks

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,11 @@ var path = require('path');
 function getAssetsFileOptions(folder, compilation) {
     var fileOptions = [];
     compilation.chunks.forEach(function(chunk) {
+		//re-upload only changed files
+		if(!chunk.rendered) {
+			return;
+		}
+		
         chunk.files.forEach(function(filePath) {
             fileOptions.push({
                 folder: path.join(folder, path.dirname(filePath)),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "license": "ISC",
   "dependencies": {
     "path": "^0.12.7",
-    "spsave": "^3.0.2"
+    "spsave": "^3.1.0"
   }
 }


### PR DESCRIPTION
First of all thank you for the great plugin! For the last few months I found myself writing more "webpack" rather than "gulp" :) thus your plugin is extremely useful.     

I've added small performance optimization - when using multiple chunks with webpack, for example in a following config:  
```javascript
entry: {
        'wp1': './src/webparts/wp1.ts',
        'wp2': './src/webparts/wp2.ts'
    },
```
and with CommonsChunkPlugin for splitting vendor and common code it uploads all chunks every time when I change only one chunk (file). For example I've changed wp1.ts, then wp1.js, wp2.js and vendor.js (and source maps) get uploaded, but webpack rendered only wp1.js and wp1.js.map. I've added a check if module is rendered. Now chunks get uploaded only in case if there is a change in dependent files. 