### PR TITLE
Using native webpack 4 plugin registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var utils = require('./lib/utils');
 function apply(options, compiler) {
 
     // When assets are being emmited (not yet on file system)
-    compiler.plugin('emit', function (compilation, callback) {
+    compiler.hooks.emit.tapAsync('spsave-webpack-plugin', function(compilation, callback) {
         
         // Build promises and execute all at once
         var assetsFileOptions = utils.getAssetsFileOptions(options.fileOptions.folder, compilation);


### PR DESCRIPTION
Changed webpack plugin registration for webpack 4, so that the deprecation warning `(node:30604) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead` is fixed. See [https://blog.johnnyreilly.com/2018/01/finding-webpack-4-use-map.html](https://blog.johnnyreilly.com/2018/01/finding-webpack-4-use-map.html) for further details.