### PR TITLE
Support for HTML Webpack Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-SPSave Webpack Plugin
-===================
+# SPSave Webpack Plugin
 
-This is a [webpack](http://webpack.github.io/) plugin that allows you upload generated assets to a SharePoint site. 
+This is a [webpack](http://webpack.github.io/) plugin that allows you upload generated assets to a SharePoint site.
 This uses the [spsave](https://www.npmjs.com/package/spsave) plugin to authenticate and upload to SharePoint.
 
 Maintainer: Yohan Belval [@yohanb](https://github.com/yohanb)
 
-Installation
-------------
+## Installation
+
 Install the plugin with npm:
+
 ```shell
 $ npm install spsave-webpack-plugin --save-dev
 ```
- 
-Basic Usage
------------
+
+## Basic Usage
 
 The plugin will upload all your webpack's assets to SharePoint using [spsave](https://github.com/s-KaiNet/spsave). Just add the plugin to your webpack config as follows:
 
@@ -50,20 +49,21 @@ module.exports = webpackConfig;
 This will upload the `dist/bundle.js` to the specified folder:
 ![SharePoint library result](https://i.imgur.com/SA72gNH.png=250x)
 
-Configuration
--------------
+## Configuration
+
 Since the Webpack plugin is based on the [spsave](https://www.npmjs.com/package/spsave) node module, all configuration options are 
 virtually identical. The **only difference** is the fact that you do not need to specify `fileOptions` other that the destination
 folder since the uploaded files will be the ones emitted by the Webpack build.
 **NOTE:** This plugin is not intended to be used when in a _hot-reloading_ Webpack setup.
 
-New in version 2.0
----------------
+## Version History
+
+### Version 2.0
 
 - Webpack 4.0 support (not compatible with older Webpack versions anymore)
 - Support for [HTML Webpack Plugin](https://www.npmjs.com/package/html-webpack-plugin)
 - Fixed issue with wrong folder structure on SharePoint (flat folder structure instead of intended folder structure)
 
-# License
+## License
 
 This project is licensed under MIT.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ virtually identical. The **only difference** is the fact that you do not need to
 folder since the uploaded files will be the ones emitted by the Webpack build.
 **NOTE:** This plugin is not intended to be used when in a _hot-reloading_ Webpack setup.
 
+New in version 2.0
+---------------
+
+- Webpack 4.0 support (not compatible with older Webpack versions anymore)
+- Support for [HTML Webpack Plugin](https://www.npmjs.com/package/html-webpack-plugin)
+- Fixed issue with wrong folder structure on SharePoint (flat folder structure instead of intended folder structure)
+
 # License
 
 This project is licensed under MIT.

--- a/index.js
+++ b/index.js
@@ -1,27 +1,53 @@
-var spsave = require('spsave').spsave;
-
-var utils = require('./lib/utils');
+var path = require('path');
+const spsave = require('spsave').spsave;
+const utils = require('./lib/utils');
 
 function apply(options, compiler) {
 
+    //Hook into plugins
+    compiler.hooks.compilation.tap('spsave-webpack-plugin', function (compilation) {
+        // HTML Webpack Plugin support
+        if (compilation.hooks.htmlWebpackPluginAfterHtmlProcessing != null) {
+            compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync('spsave-webpack-plugin', function (htmlWebpackCompilation, htmlWebpackCallback) {
+                var htmlFile = htmlWebpackCompilation.outputName;
+                var htmlFileTargetFolder = utils.getTargetFolder(options.fileOptions.folder, htmlFile);
+                var content = htmlWebpackCompilation.html;
+                var fileOptions = {
+                    folder: htmlFileTargetFolder,
+                    fileName: path.basename(htmlFile),
+                    fileContent: content
+                };
+                // console.log(JSON.stringify(fileOptions));
+                spsave(options.coreOptions, options.credentialOptions, fileOptions)
+                    .then(function () {
+                        htmlWebpackCallback();
+                    })
+                    .catch(function (error) {
+                        console.log(error);
+                        htmlWebpackCallback();
+                    });
+            });
+        }
+    });
+
     // When assets are being emmited (not yet on file system)
-    compiler.hooks.emit.tapAsync('spsave-webpack-plugin', function(compilation, callback) {
-        
+    compiler.hooks.emit.tapAsync('spsave-webpack-plugin', function (compilation, callback) {
         // Build promises and execute all at once
         var assetsFileOptions = utils.getAssetsFileOptions(options.fileOptions.folder, compilation);
-        var spSavePromises = assetsFileOptions.map(function(fileOptions) {
+        var spSavePromises = assetsFileOptions.map(function (fileOptions) {
             return spsave(options.coreOptions, options.credentialOptions, fileOptions);
         })
 
         Promise.all(spSavePromises)
-            .then(function() {
+            .then(function () {
                 callback();
             })
-            .catch(function(error) {
+            .catch(function (error) {
                 console.log(error);
                 callback();
             });
     });
+
 }
 
 function SPSavePlugin(options) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,18 +9,24 @@ function getAssetsFileOptions(folder, compilation) {
 		}
 		
         chunk.files.forEach(function(filePath) {
-            var newFolder = path.join(folder, path.dirname(filePath));
-			newFolder = folder.replace(/\\/g, '/');
+            var newFolder = getTargetFolder(folder, filePath);
             fileOptions.push({
                 folder: newFolder,
                 fileName: path.basename(filePath),
                 fileContent: compilation.assets[filePath].source()})
-      });
+        });
     });
 
     return fileOptions;
 }
 
+function getTargetFolder(baseFolder, filePath) {
+    var newFolder = path.join(baseFolder, path.dirname(filePath));
+    newFolder = newFolder.replace(/\\/g, '/');
+    return newFolder;
+}
+
 module.exports = {
-    getAssetsFileOptions
+    getAssetsFileOptions,
+    getTargetFolder
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spsave-webpack-plugin",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "Webpack plugin that uploads webpack assets to SharePoint using the spsave npm module.",
   "main": "index.js",
   "repository": "yohanb/spsave-webpack-plugin.git",


### PR DESCRIPTION
- Support for [HTML Webpack Plugin](https://www.npmjs.com/package/html-webpack-plugin)
- Fixed issue with wrong folder structure on SharePoint (flat folder structure instead of intended folder structure)
- Bumped version to 2.0 to indicate that this is not backwards compatible (as mentioned in PR #7)
- Reformatted Readme.md so that the markdown linter does not complain as much